### PR TITLE
added post install event

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -208,3 +208,8 @@ if [ $vmajor -gt 5 ] || [ $vmajor -eq 5 -a $vminor -gt 2 ]; then
     cd "$basedir"
     ./pyrus.sh "$version" "$instdir"
 fi
+
+#post install operations
+if [ -f 'post-install.sh' ]; then
+    ./post-install.sh $version
+fi


### PR DESCRIPTION
- allows to run commands after php is installed, so you can for example automatically install extensions, copy cgi to your web server and so on...
- in combination with https://github.com/cweiske/phpfarm/pull/2 you run just ./compile 5.3.23 and php 5.3.23 is running (no need to do additional operations manually)
