### PR TITLE
better support for custom $initarget

### DIFF
--- a/src/compile.sh
+++ b/src/compile.sh
@@ -142,6 +142,12 @@ fi
 if [ "x$initarget" = x ]; then
     initarget="$instdir/lib/php.ini"
 fi
+
+initarget_dir=$(dirname "$initarget")
+if [ ! -d "$initarget_dir" ] && ! mkdir -p -m 755 "$initarget_dir"; then
+  echo "Warning: failed to created directory $initarget_dir." 1>&2
+fi
+
 if [ -f "php.ini-development" ]; then
     #php 5.3
     cp "php.ini-development" "$initarget"
@@ -206,5 +212,5 @@ ln -fs "$instdir/bin/phpize" "$shbindir/phpize-$version"
 
 if [ $vmajor -gt 5 ] || [ $vmajor -eq 5 -a $vminor -gt 2 ]; then
     cd "$basedir"
-    ./pyrus.sh "$version" "$instdir"
+    ./pyrus.sh "$version" "$instdir" "$initarget"
 fi

--- a/src/pyrus.sh
+++ b/src/pyrus.sh
@@ -10,6 +10,7 @@ fi
 
 version="$1"
 instdir="$2"
+initarget="${3:-$instdir/lib/php.ini}"
 
 if [ ! -d "$instdir" ]; then
     echo "PHP installation directory does not exist: $instdir"
@@ -45,4 +46,4 @@ chmod +x "$pyrusbin"
 #symlink
 ln -sf "$pyrusbin" "$instdir/../bin/pyrus-$version"
 
-echo "include_path=\".:$instdir/pear/php/\"" >> "$instdir/lib/php.ini"
+echo "include_path=\".:$instdir/pear/php/\"" >> "$initarget"


### PR DESCRIPTION
Fixes a few limitations for better supporting a custom $initarget, e.g. $instdir/etc/php.ini. Before this commit, if the parent dir of $initarget doesn't exist, the copying of it to the target dir fails, and pyrus.sh run in the end of compile.sh also fails. In addition, pyrus.sh used a hardcoded $initarget as $instdir/lib/php.ini.
